### PR TITLE
Open STLs directly with imagej-mesh-io

### DIFF
--- a/src/fun/imagej/mesh.clj
+++ b/src/fun/imagej/mesh.clj
@@ -30,13 +30,22 @@
 ; Deprecated
 (def write-mesh-as-stl save)
 
+; Use SciJava IOService to resolve filetype
 (defn open
   "Open a mesh from file."
   [filename]
   (.open (.io (ij/get-ij))
          filename))
 
-(def read-stl-mesh open)
+(defn open-stl
+  "Open a STL mesh by directly calling imagej-mesh-io"
+  [filename]
+  (let [mesh (net.imagej.mesh.naive.NaiveFloatMesh.)
+        stlmeshio (net.imagej.mesh.io.stl.STLMeshIO.)]
+    (.read stlmeshio mesh (java.io.File. filename))
+    mesh))
+
+(def read-stl-mesh open-stl)
 
 (defn slurp-bytes
   "Slurp the bytes from a slurpable thing"
@@ -45,7 +54,7 @@
     (clojure.java.io/copy (clojure.java.io/input-stream x) out)
     (.toByteArray out)))
 
-(def read-stl open)
+(def read-stl open-stl)
 
 #_(defn read-stl-vertices
    "Read a mesh from a STL file."

--- a/src/plugins/Scripts/Plugins/FunImageJ/Mesh/voxelize_mesh.clj
+++ b/src/plugins/Scripts/Plugins/FunImageJ/Mesh/voxelize_mesh.clj
@@ -22,7 +22,7 @@
 (ij/setup-context (ns-resolve 'user 'ctxt) 'user)
 
 #_(do ; Bindings for testing
-  (def mesh-filename "/Users/kharrington/git/brevis/resources/obj/sphere.stl")
+  (def mesh-filename (java.io.File. "Cute_Little_Elephant.stl"))
   (def width 100)
   (def height 100)
   (def depth 100))


### PR DESCRIPTION
This PR is a fix for https://forum.image.sc/t/unable-to-convert-stl-to-stacks/20601/17, which describes a bug in the voxelization command.